### PR TITLE
Fix transaction count leading zeros

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -13,7 +13,6 @@ var async = require("async");
 var BlockchainDouble = require("./blockchain_double.js");
 var ForkedBlockchain = require("./utils/forkedblockchain.js");
 var Web3 = require('web3');
-var async = require("async");
 var util = require("util");
 
 var to = require('./utils/to');
@@ -210,7 +209,7 @@ StateManager.prototype.getBalance = function(address, number, callback) {
 StateManager.prototype.getTransactionCount = function(address, number, callback) {
   this.blockchain.getNonce(address, number, function(err, nonce) {
     if (nonce) {
-      nonce = to.hex(nonce);
+      nonce = to.hexWithoutLeadingZeroes(nonce);
     }
     callback(err, nonce);
   });

--- a/lib/utils/to.js
+++ b/lib/utils/to.js
@@ -30,7 +30,13 @@ module.exports = {
 
   hexWithoutLeadingZeroes: function(val) {
     val = this.hex(val);
-    return "0x" + val.replace("0x", "").replace(/^0+/, "");
+    val = "0x" + val.replace("0x", "").replace(/^0+/, "");
+
+    if (val == "0x") {
+      val = "0x0";
+    }
+
+    return val;
   },
 
   number: function(val) {


### PR DESCRIPTION
As described [here](https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding) (emphasis mine):

> When encoding QUANTITIES (integers, numbers): encode as hex, prefix with "0x", the **most compact representation** (slight exception: zero should be represented as "0x0").

The implementation of `getTransactionCount` would encode numbers including a leading zero, for example: `4` would become `0x04` instead of the correct way `0x4`.

This PR fixes it, and also fixes the function `hexWithoutLeadingZeroes` in `lib/utils/to.js` to correctly convert `0` to `0x0` instead of `0x` (which would lead to an exception in [Web3js when creating a BigNumber](https://github.com/ethereum/web3.js/blob/306680f8d917f912d9c6ed632d133274909cee87/lib/utils/utils.js#L356-L367), more specifically at line 363).

I tried to add a test for this change, but as Web3 already returns the decoded number, I wasn't able to find the right place to check that the hex string is returned correctly.